### PR TITLE
initial implementation of marketplace spec for On-Demand API

### DIFF
--- a/applications/unity-on-demand-api/0.1/metadata.json
+++ b/applications/unity-on-demand-api/0.1/metadata.json
@@ -1,0 +1,37 @@
+{
+  "DisplayName": "Unity On-Demand API",
+  "Name": "unity-on-demand-api",
+  "Version": "0.1-beta",
+  "Channel": "beta",
+  "Owner": "U-OD Team",
+  "Description": "A package to install and configure an On-Demand API for your Unity SPS",
+  "Repository": "https://github.com/unity-sds/unity-on-demand-api/",
+  "Tags": [
+    "api",
+    "http",
+    "rest",
+    "on-demand"
+  ],
+  "Category": "on-demand",
+  "IamRoles": {
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "iam:CreateInstanceProfile"
+        ],
+        "Resource": [
+          "arn:aws:iam::<account_id>:instance-profile/eksctl*"
+        ]
+      }
+    ]
+  },
+  "Package": "https://github.com/unity-sds/unity-on-demand-api/",
+  "Backend": "terraform",
+  "WorkDirectory": "terraform-unity",
+  "DefaultDeployment": {
+    "Variables": {
+      "deploy_script_path": "./deploy.sh"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the initial implementation of the marketplace definition for the On-Demand API. It is not meant as the final definition but serves to test that the On-Demand API marketplace item shows up in the management console.

See https://github.com/unity-sds/unity-on-demand/issues/29 for more info.