### PR TITLE
Update metadata.json

### DIFF
--- a/applications/unity-proxy/0.13/metadata.json
+++ b/applications/unity-proxy/0.13/metadata.json
@@ -1,7 +1,7 @@
 {
 		"DisplayName": "Unity Proxy",
 		"Name": "unity-proxy",
-		"Version": "0.13",
+		"Version": "0.13.0",
 		"Channel": "beta",
 		"Owner": "Tom Barber",
 		"Description": "The Unity HTTPD Proxy package",
@@ -12,7 +12,7 @@
 		],
 		"Category": "system",
 		"IamRoles": {},
-		"Package": "https://github.com/unity-sds/unity-proxy",
+		"Package": "https://github.com/unity-sds/unity-proxy@e5638b3",
 		"Backend": "terraform",
 		"ManagedDependencies": {},
 		"DefaultDeployment": {},


### PR DESCRIPTION
Updated version to 0.13.0 of proxy. installs unity-proxy at commit e5638b3. Major change here is the SSM rename of the lambda and we hard coded the version of the docker container in use (0.13.0) so that ti dwouldn't be different based on when it was installed (e.g. using latest).