### PR TITLE
Removed commit hash for Unity UI version 0.8.0.

### DIFF
--- a/applications/unity-ui/0.8.0/metadata.json
+++ b/applications/unity-ui/0.8.0/metadata.json
@@ -12,7 +12,7 @@
    ],
    "Category": "ui",
    "IamRoles": {},
-   "Package": "https://github.com/unity-sds/unity-ui-infra@0d6ddf2df0d2d1706f6aa7683979ceb9a6e86266",
+   "Package": "https://github.com/unity-sds/unity-ui-infra",
    "ManagedDependencies": {},
    "Backend": "terraform",
    "WorkDirectory": "terraform-unity-ui",


### PR DESCRIPTION
The management console is not working as expected, so I am removing the commit hash from the Unity UI 0.8.0 version in an attempt to troubleshoot the issue.